### PR TITLE
Token based auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'
 gem 'jbuilder', '~> 2.5'
 gem 'rack-cors'
-gem 'devise'
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.6'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'devise_token_auth'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.6'
+  gem 'rails-controller-testing'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.4)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -178,6 +182,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rack-cors
   rails (~> 5.1.4)
+  rails-controller-testing
   rspec-rails (~> 3.6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       railties (>= 4.1.0, < 5.2)
       responders
       warden (~> 1.2.3)
+    devise_token_auth (0.1.42)
+      devise (> 3.5.2, <= 4.3)
+      rails (< 6)
     diff-lcs (1.3)
     erubi (1.7.0)
     factory_girl (4.8.1)
@@ -167,7 +170,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   database_cleaner
-  devise
+  devise_token_auth
   factory_girl_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::API
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    added_attrs = [:nickname]
+    devise_parameter_sanitizer.permit(:sign_up, keys: added_attrs)
+    devise_parameter_sanitizer.permit(:account_update, keys: added_attrs)
+  end
 end

--- a/app/controllers/v1/base_controller.rb
+++ b/app/controllers/v1/base_controller.rb
@@ -1,9 +1,5 @@
 class V1::BaseController < ApplicationController
-  before_action :authenticate_user_from_token!
-  # before_action :authenticate_user!
+  include DeviseTokenAuth::Concerns::SetUserByToken
 
-  private
-
-  def authenticate_user_from_token!
-  end
+  before_action :authenticate_user!
 end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -1,0 +1,5 @@
+class V1::UsersController < V1::BaseController
+  def show
+    @user = current_user
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
 
   has_many :evaluations
 end

--- a/app/views/v1/users/show.json.jbuilder
+++ b/app/views/v1/users/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.(@user, :email, :nickname)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.logger = Logger.new(STDOUT)
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -34,7 +34,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:username]
+  config.authentication_keys = [:email]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -46,12 +46,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:username]
+  config.case_insensitive_keys = [:email]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:username]
+  config.strip_whitespace_keys = [:email]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -139,7 +139,7 @@ Devise.setup do |config|
   config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
-  # config.confirmation_keys = [:email]
+  config.confirmation_keys = [:email]
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
@@ -198,7 +198,7 @@ Devise.setup do |config|
   # ==> Configuration for :recoverable
   #
   # Defines which key will be used when recovering the password for an account
-  # config.reset_password_keys = [:email]
+  config.reset_password_keys = [:email]
 
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,48 @@
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -3,7 +3,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
@@ -28,7 +28,7 @@ DeviseTokenAuth.setup do |config|
   # Uncomment to enforce current_password param to be checked before all
   # attribute updates. Set it to :password if you want it to be checked only if
   # password is updated.
-  # config.check_current_password_before_update = :attributes
+  config.check_current_password_before_update = :password
 
   # By default we will use callbacks for single omniauth.
   # It depends on fields like email, provider and uid.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
     resources :lectures, only: [:index, :show] do
       resources :evaluations, only: [:index, :create, :update, :destroy]
     end
+    resource :user, only: [:show]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  mount_devise_token_auth_for 'User', at: 'v1/user'
+
   namespace :v1, defaults: { format: :json } do
-    devise_for :users
     resources :lectures, only: [:index, :show] do
       resources :evaluations, only: [:index, :create, :update, :destroy]
     end

--- a/db/migrate/20171021083339_devise_token_auth_users.rb
+++ b/db/migrate/20171021083339_devise_token_auth_users.rb
@@ -1,0 +1,15 @@
+class DeviseTokenAuthUsers < ActiveRecord::Migration[5.1]
+  def change
+    change_table(:users) do |t|
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      t.string :email
+
+      t.json :tokens
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, [:uid, :provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171018153037) do
+ActiveRecord::Schema.define(version: 20171021083339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,8 +86,14 @@ ActiveRecord::Schema.define(version: 20171018153037) do
     t.datetime "confirmation_sent_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "email"
+    t.json "tokens"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 

--- a/spec/controllers/v1/users_controller_spec.rb
+++ b/spec/controllers/v1/users_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe V1::UsersController, type: :controller do
+  describe 'GET #show' do
+    let(:show_request) { get :show }
+
+    it { show_request; expect(assigns(:user)).to eq(user)}
+    it { expect(show_request).to be_successful }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :user do
+    sequence(:email) { |n| "email#{n}@snu.ac.kr" }
+    password "password"
+  end
+end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,0 +1,20 @@
+module V1ControllerHelper
+  extend ActiveSupport::Concern
+
+  included do
+    before do
+      request.env['HTTP_ACCEPT'] = 'application/json'
+      request.env['HTTP_UID'] = auth_token['uid']
+      request.env['HTTP_CLIENT'] = auth_token['client']
+      request.env['HTTP_ACCESS_TOKEN'] = auth_token['access-token']
+    end
+
+    let(:user) { create(:user) }
+    let(:auth_token) { user.create_new_auth_token.slice('uid', 'client', 'access-token') }
+  end
+end
+
+RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include V1ControllerHelper, type: :controller
+end


### PR DESCRIPTION
[devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth)를 이용한 token 기반 인증 설정.

## Endpoints

### `POST /v1/user`

회원 가입
parameters: `email`, `password`, `nickname`

### `POST /v1/users/sign_in`

로그인
parameters: `email`, `password`

### `DELETE /v1/users/sign_out`

로그아웃
인증 헤더 필요


나머지 endpoint는 https://github.com/lynndylanhurley/devise_token_auth#usage-tldr 참고

### 인증 헤더

회원가입, 로그인 시 response header에 포함된 `client`, `access-token`, `uid`를 심어보내면 됨.
