### PR TITLE
Restrict evaluation api unless confirmed

### DIFF
--- a/app/controllers/v1/evaluations_controller.rb
+++ b/app/controllers/v1/evaluations_controller.rb
@@ -8,6 +8,7 @@ class V1::EvaluationsController < V1::BaseController
   end
 
   def create
+    authorize! :create, Evaluation
     @evaluation = Evaluation.create!(evaluation_params.merge(user: current_user, lecture: @lecture))
     render :show
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,7 +4,9 @@ class Ability
   def initialize(user)
     user ||= User.new
 
-    can [:read, :create], Evaluation
+    if user.confirmed?
+      can [:read, :create], Evaluation
+    end
     can [:update, :destroy], Evaluation, user_id: user.id
   end
 end

--- a/app/serializable/serializable_user.rb
+++ b/app/serializable/serializable_user.rb
@@ -6,4 +6,8 @@ class SerializableUser < JSONAPI::Serializable::Resource
   attribute :created_at
   attribute :updated_at
   attribute :email
+
+  attribute :is_confirmed do
+    @object.confirmed?
+  end
 end

--- a/spec/controllers/v1/evaluations_controller_spec.rb
+++ b/spec/controllers/v1/evaluations_controller_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe V1::EvaluationsController, type: :controller do
       it { expect(index_request).to be_successful }
       it { index_request; expect(assigns(:evaluations)).to eq(evaluations) }
     end
+
+    context 'when user not confirmed' do
+      let(:user) { create(:user) }
+
+      it { expect(index_request).not_to be_successful }
+    end
   end
 
   describe '#POST create' do
@@ -38,6 +44,12 @@ RSpec.describe V1::EvaluationsController, type: :controller do
 
       it { expect(create_request).not_to be_successful }
       it { expect { create_request }.not_to change(lecture.evaluations, :count) }
+    end
+
+    context 'when user not confirmed' do
+      let(:user) { create(:user) }
+
+      it { expect(create_request).not_to be_successful }
     end
   end
 

--- a/spec/controllers/v1/users_controller_spec.rb
+++ b/spec/controllers/v1/users_controller_spec.rb
@@ -4,8 +4,19 @@ RSpec.describe V1::UsersController, type: :controller do
   describe 'GET #show' do
     let(:show_request) { get :show }
 
-    it { show_request; expect(assigns(:user)).to eq(user)}
-    it { expect(show_request).to be_successful }
+    context 'when confirmed' do
+      it { show_request; expect(assigns(:user)).to eq(user)}
+      it { expect(show_request).to be_successful }
+      it { show_request; expect(json.dig('data', 'attributes', 'is_confirmed')).to eq(true) }
+    end
+
+    context 'when not confirmed' do
+      let(:user) { create(:user, confirmed_at: nil) }
+
+      it { show_request; expect(assigns(:user)).to eq(user)}
+      it { expect(show_request).to be_successful }
+      it { show_request; expect(json.dig('data', 'attributes', 'is_confirmed')).to eq(false) }
+    end
   end
 
   describe 'POST #create' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :user do
     sequence(:username) { |n| "username#{n}" }
     password "password"
+
+    trait :confirmed do
+      confirmed_at { Time.now }
+    end
   end
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -7,7 +7,7 @@ module V1ControllerHelper
       request.env['HTTP_AUTHORIZATION'] = auth_token
     end
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :confirmed) }
     let(:auth_token) { JsonWebToken.encode(user_id: user.id) }
 
     def json


### PR DESCRIPTION
* 이메일 confirm 이전에는 강의평 조회/작성 불가능하도록 제한함.
* user json attribute에 `is_confirmed` 추가