### PR TITLE
Reset password

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.4

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ And the server will be running at http://localhost:3001.
 | SMTP_PORT            | Default: `587`                            |
 | SMTP_USER_NAME       | -                                         |
 | SMTP_PASSWORD        | -                                         |
+| WEB_BASE             | Base url of web client.                   |
 
 ## Running spec
 

--- a/app/controllers/v1/reset_passwords_controller.rb
+++ b/app/controllers/v1/reset_passwords_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class V1::ResetPasswordsController < V1::BaseController
+  skip_before_action :authorize_request
+
+  def create
+    @user = User.find_by(username: params[:username].downcase)
+    if @user
+      @user.issue_reset_token
+      UserMailer.reset_email(@user).deliver_now
+    end
+    render jsonapi: nil,
+           meta: { message: I18n.t(:password_reset_delivered, scope: :messages) },
+           status: :created
+  end
+
+  def update
+    @user = User.find_by!(reset_token: params[:reset_token])
+    if @user.reset_sent_at < 1.hour.ago
+      render jsonapi: nil,
+             meta: { message: I18n.t(:password_reset_expired, scope: :messages) },
+             status: :forbidden
+    elsif @user.update(password: params[:password])
+      render jsonapi: nil,
+             meta: { message: I18n.t(:password_updated, scope: :messages) }
+    else
+      render jsonapi_errors: @user.errors, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -9,7 +9,7 @@ class V1::UsersController < V1::BaseController
   def create
     @user = User.create!(user_create_params)
     auth_token = AuthenticateUser.new(@user.username, @user.password).call
-    UserMailer.confirmation_email(@user).deliver
+    UserMailer.confirmation_email(@user).deliver_now
     render jsonapi: nil, meta: { auth_token: auth_token }, status: :created
   rescue ActiveRecord::RecordNotUnique
     raise(ExceptionHandler::DuplicateRecord, 'User already exists')

--- a/app/helpers/web_url_helper.rb
+++ b/app/helpers/web_url_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# WebUrlHelper contains url helpers for web endpoints.
+module WebUrlHelper
+  WEB_BASE = ENV['WEB_BASE'].freeze
+
+  def web_email_confirmation_url(confirmation_token)
+    query = { confirmation_token: confirmation_token }
+    "#{WEB_BASE}/confirm_email?#{query.to_param}"
+  end
+
+  def web_password_reset_url(reset_token)
+    query = { reset_token: reset_token }
+    "#{WEB_BASE}/reset_password?#{query.to_param}"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,19 @@
+# frozen_string_literal: true
+
+# User related mailer
 class UserMailer < ApplicationMailer
+  include WebUrlHelper
+
   def confirmation_email(user)
     @user = user
-    @confirmation_url = confirm_email_v1_user_url(confirmation_token: @user.confirmation_token)
+    @email_confirmation_url = web_email_confirmation_url(@user.confirmation_token)
+
+    mail(to: user.email, subject: default_i18n_subject)
+  end
+
+  def reset_email(user)
+    @user = user
+    @password_reset_url = web_password_reset_url(@user.reset_token)
 
     mail(to: user.email, subject: default_i18n_subject)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   before_validation :set_confirmation_token, on: :create
 
   validates_presence_of :username, :email, :password_digest
+  validates :password, length: { minimum: 8 }, allow_nil: true
 
   def confirmed?
     confirmed_at.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,13 @@ class User < ApplicationRecord
     update!(confirmed_at: DateTime.current, confirmation_token: nil)
   end
 
+  def issue_reset_token
+    update(
+      reset_token: random_token,
+      reset_sent_at: DateTime.current
+    )
+  end
+
   private
 
   def set_email_from_username
@@ -24,6 +31,10 @@ class User < ApplicationRecord
   end
 
   def set_confirmation_token
-    self.confirmation_token = SecureRandom.urlsafe_base64.to_s
+    self.confirmation_token = random_token
+  end
+
+  def random_token
+    SecureRandom.urlsafe_base64.to_s
   end
 end

--- a/app/views/user_mailer/confirmation_email.html.erb
+++ b/app/views/user_mailer/confirmation_email.html.erb
@@ -1,3 +1,3 @@
 <p><%= t('.content') %></p>
 
-<%= link_to @confirmation_url, @confirmation_url %>
+<%= link_to @email_confirmation_url, @email_confirmation_url%>

--- a/app/views/user_mailer/reset_email.html.erb
+++ b/app/views/user_mailer/reset_email.html.erb
@@ -1,0 +1,5 @@
+<p><%= t('.content') %></p>
+
+<%= link_to @password_reset_url, @password_reset_url%>
+
+<p><%= t('.ignore_when_not_requested') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  messages:
+    password_reset_delivered: 'Reset email has been sent to your mysnu account.'
+    password_reset_expired: 'Your password reset request is expired. Try again.'
+    password_updated: 'Successfully updated password.'
   activerecord:
     errors:
       messages:
@@ -12,3 +16,7 @@ en:
     confirmation_email:
       subject: "[SNUEV] Registration Confirmation"
       content: Thanks for registering! Click URL below to complete confirmation.
+    reset_email:
+      subject: '[SNUEV] Password reset'
+      content: 'Click URL below to reset your password.'
+      ignore_when_not_requested: 'If you did not request your password to be reset, just ignore this email and your password will continue to stay the same.'

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,4 +1,8 @@
 ko:
+  messages:
+    password_reset_delivered: '비밀번호 초기화 메일이 마이스누 계정으로 발송되었습니다.'
+    password_reset_expired: '비밀번호 초기화 링크가 만료되었습니다. 다시 시도해 주세요.'
+    password_updated: '비밀번호가 성공적으로 변경되었습니다.'
   activerecord:
     attributes:
       evaluation:
@@ -17,6 +21,10 @@ ko:
     confirmation_email:
       subject: '[SNUEV] 서울대학교 강의평가 서비스 인증 메일'
       content: '가입해주셔서 감사합니다! 아래의 링크를 이용해 이메일 인증을 완료해 주세요.'
+    reset_email:
+      subject: '[SNUEV] 서울대학교 강의평가 서비스 비밀번호 초기화'
+      content: '아래의 링크로 이동해 비밀번호를 새로 설정해 주세요.'
+      ignore_when_not_requested: '만약 비밀번호 초기화를 요청하지 않았다면, 본 이메일은 무시해 주시기 바랍니다.'
   date:
     abbr_day_names:
     - 일

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
       delete :sign_out, to: 'auth#sign_out'
 
       get :confirm_email
+
+      resource :reset_password, only: [:create, :update]
     end
   end
 

--- a/db/migrate/20171112065743_add_reset_to_users.rb
+++ b/db/migrate/20171112065743_add_reset_to_users.rb
@@ -1,0 +1,7 @@
+class AddResetToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :reset_token, :string
+    add_column :users, :reset_sent_at, :datetime
+    add_index :users, :reset_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171108153726) do
+ActiveRecord::Schema.define(version: 20171112065743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,8 +89,11 @@ ActiveRecord::Schema.define(version: 20171108153726) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.string "reset_token"
+    t.datetime "reset_sent_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_token"], name: "index_users_on_reset_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 

--- a/spec/controllers/v1/reset_passwords_controller_spec.rb
+++ b/spec/controllers/v1/reset_passwords_controller_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe V1::ResetPasswordsController, type: :controller do
+  describe 'POST #create' do
+    let(:create_request) { post :create, params: { username: 'user' } }
+    let(:auth_token) { nil }
+
+    context 'when user exists' do
+      let(:user) { create(:user, username: 'user') }
+
+      before { user }
+
+      it { expect(create_request).to be_successful }
+      it { expect { create_request }.to change { user.reload.reset_token }.from(nil) }
+      it { expect { create_request }.to change { ActionMailer::Base.deliveries.count }.by(1) }
+    end
+
+    context 'when user not exist' do
+      it { expect(create_request).to be_successful }
+      it { expect { create_request }.not_to change { ActionMailer::Base.deliveries.count } }
+    end
+  end
+
+  describe 'PUT #update' do
+    let(:update_request) { put :update, params: { reset_token: reset_token, password: password } }
+    let(:password) { 'new_password' }
+    let(:auth_token) { nil }
+
+    context 'when valid reset_token' do
+      let(:reset_token) { user.reset_token }
+
+      before { user.issue_reset_token }
+
+      it { expect(update_request).to be_successful }
+      it { expect { update_request }.to change { user.reload.password_digest } }
+
+      context 'when invalid new password' do
+        let(:password) { 'short' }
+
+        it { expect(update_request).not_to be_successful }
+        it { expect(update_request).to have_http_status(:unprocessable_entity) }
+        it { expect { update_request }.not_to change { user.reload.password_digest } }
+      end
+    end
+
+    context 'when reset_token not found' do
+      let(:reset_token) { 'nonexist' }
+
+      it { expect(update_request).not_to be_successful }
+      it { expect(update_request).to have_http_status(:not_found) }
+    end
+
+    context 'when reset_token expired' do
+      let(:reset_token) { user.reset_token }
+
+      before do
+        user.issue_reset_token
+        user.update(reset_sent_at: Time.now - 1.year)
+      end
+
+      it { expect(update_request).not_to be_successful }
+      it { expect(update_request).to have_http_status(:forbidden) }
+      it { expect { update_request }.not_to change { user.reload.password_digest } }
+    end
+  end
+end

--- a/spec/helpers/web_url_helper_spec.rb
+++ b/spec/helpers/web_url_helper_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe WebUrlHelper, type: :helper do
+  before { stub_const('WebUrlHelper::WEB_BASE', 'https://snuev.kr') }
+
+  describe '#web_email_confirmation_url' do
+    let(:confirmation_token) { 'abc' }
+    subject(:web_email_confirmation_url) { helper.web_email_confirmation_url(confirmation_token) }
+
+    it { expect(subject).to eq('https://snuev.kr/confirm_email?confirmation_token=abc') }
+  end
+
+  describe '#web_reset_password_url' do
+    let(:reset_token) { 'abc' }
+    subject(:web_reset_password_url) { helper.web_password_reset_url(reset_token) }
+
+    it { expect(subject).to eq('https://snuev.kr/reset_password?reset_token=abc') }
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe UserMailer, type: :mailer do
     it { expect(mail.to).to eq([user.email]) }
     it { expect(mail.body.encoded).to match(user.confirmation_token) }
   end
+
+  describe '#reset_email' do
+    let(:user) { create(:user) }
+    let(:mail) { described_class.reset_email(user).deliver_now }
+
+    before { user.issue_reset_token }
+
+    it { expect(mail.subject).not_to be_blank }
+    it { expect(mail.to).to eq([user.email]) }
+    it { expect(mail.body.encoded).to match(user.reset_token) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe '#valid?' do
+    it { expect(build(:user, password: 'short')).not_to be_valid }
+    it { expect(build(:user, password: 'long_password')).to be_valid }
+  end
+
   describe '#set_email_from_username' do
     let(:user) { build(:user, username: 'user') }
 


### PR DESCRIPTION
## 비밀번호 초기화 플로우

### `POST /v1/user/reset_password`

비밀번호 초기화 메일 발송.

#### Parameters

* `username`

### `PATCH /v1/user/reset_password`

비밀번호 초기화. 메일로 전송된 `reset_token` 필요

#### Parameters

* `reset_token`
* `password`

### 기타

* 비밀번호 초기화 링크는 웹앱으로 리디렉션하기 때문에 rails url helper로 경로 생성 불가능하므로 웹 링크들을 생성하기 위한 `WebUrlHelper` 모듈을 추가함.