### PR TITLE
Fix confirmation

### DIFF
--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -6,6 +6,7 @@ module ExceptionHandler
   class MissingToken < StandardError; end
   class InvalidToken < StandardError; end
   class ExpiredSignature < StandardError; end
+  class InvalidConfirmationToken < StandardError; end
 
   included do
     rescue_from ActiveRecord::RecordInvalid, with: :render_invalid_request
@@ -16,6 +17,7 @@ module ExceptionHandler
     rescue_from ExceptionHandler::InvalidToken, with: :render_unauthorized
     rescue_from ExceptionHandler::ExpiredSignature, with: :render_unauthorized
     rescue_from ExceptionHandler::DuplicateRecord, with: :render_invalid_request
+    rescue_from ExceptionHandler::InvalidConfirmationToken, with: :render_forbidden
   end
 
   private

--- a/app/controllers/v1/confirmations_controller.rb
+++ b/app/controllers/v1/confirmations_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class V1::ConfirmationsController < V1::BaseController
+  skip_before_action :authorize_request, only: :update
+
+  def create
+    current_user.issue_confirmation_token
+    UserMailer.confirmation_email(current_user).deliver_now
+    render jsonapi: nil,
+           meta: { message: I18n.t(:confirmation_delivered, scope: :messages) },
+           status: :created
+  end
+
+  def update
+    @user = User.find_by!(confirmation_token: params[:confirmation_token])
+    if @user.confirmation_sent_at < 1.hour.ago
+      render jsonapi_errors: { title: I18n.t(:confirmation_expired, scope: :messages) }, status: :forbidden
+    elsif @user.confirm_email
+      render jsonapi: nil, meta: { message: I18n.t(:confirmation_successful, scope: :messages) }
+    else
+      render jsonapi_errors: @user.errors, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/v1/reset_passwords_controller.rb
+++ b/app/controllers/v1/reset_passwords_controller.rb
@@ -17,12 +17,9 @@ class V1::ResetPasswordsController < V1::BaseController
   def update
     @user = User.find_by!(reset_token: params[:reset_token])
     if @user.reset_sent_at < 1.hour.ago
-      render jsonapi: nil,
-             meta: { message: I18n.t(:password_reset_expired, scope: :messages) },
-             status: :forbidden
+      render jsonapi_errors: { title: I18n.t(:password_reset_expired, scope: :messages) }, status: :forbidden
     elsif @user.update(password: params[:password])
-      render jsonapi: nil,
-             meta: { message: I18n.t(:password_updated, scope: :messages) }
+      render jsonapi: nil, meta: { message: I18n.t(:password_updated, scope: :messages) }
     else
       render jsonapi_errors: @user.errors, status: :unprocessable_entity
     end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -9,6 +9,7 @@ class V1::UsersController < V1::BaseController
   def create
     @user = User.create!(user_create_params)
     auth_token = AuthenticateUser.new(@user.username, @user.password).call
+    @user.issue_confirmation_token
     UserMailer.confirmation_email(@user).deliver_now
     render jsonapi: nil, meta: { auth_token: auth_token }, status: :created
   rescue ActiveRecord::RecordNotUnique
@@ -25,13 +26,6 @@ class V1::UsersController < V1::BaseController
     @user = current_user
     @user.destroy
     render jsonapi: @user
-  end
-
-  def confirm_email
-    @user = User.find_by(confirmation_token: params[:confirmation_token])
-    raise(ExceptionHandler::InvalidConfirmationToken, 'Invalid Email Confirmation') unless @user
-    @user.confirm_email!
-    render jsonapi: nil, meta: { message: 'Email confirmation successful' }
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   has_many :evaluations
 
   before_validation :set_email_from_username, on: :create
-  before_validation :set_confirmation_token, on: :create
 
   validates_presence_of :username, :email, :password_digest
   validates :password, length: { minimum: 8 }, allow_nil: true
@@ -13,8 +12,8 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
-  def confirm_email!
-    update!(confirmed_at: DateTime.current, confirmation_token: nil)
+  def confirm_email
+    update(confirmed_at: DateTime.current, confirmation_token: nil)
   end
 
   def issue_reset_token
@@ -24,14 +23,17 @@ class User < ApplicationRecord
     )
   end
 
+  def issue_confirmation_token
+    update(
+      confirmation_token: random_token,
+      confirmation_sent_at: DateTime.current
+    )
+  end
+
   private
 
   def set_email_from_username
     self.email ||= "#{username}@snu.ac.kr"
-  end
-
-  def set_confirmation_token
-    self.confirmation_token = random_token
   end
 
   def random_token

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 en:
   messages:
+    confirmation_delivered: 'Confirmation email has been sent to your mysnu account.'
+    confirmation_expired: 'Your confirmation request is expired. Try again.'
+    confirmation_successful: 'Successfully confirmed your mysnu account.'
     password_reset_delivered: 'Reset email has been sent to your mysnu account.'
     password_reset_expired: 'Your password reset request is expired. Try again.'
     password_updated: 'Successfully updated password.'

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,5 +1,8 @@
 ko:
   messages:
+    confirmation_delivered: '인증 메일이 전송되었습니다.'
+    confirmation_expired: '인증 URL이 만료되었습니다. 다시 시도해 주세요'
+    confirmation_successful: '마이스누 계정 인증에 성공하였습니다.'
     password_reset_delivered: '비밀번호 초기화 메일이 마이스누 계정으로 발송되었습니다.'
     password_reset_expired: '비밀번호 초기화 링크가 만료되었습니다. 다시 시도해 주세요.'
     password_updated: '비밀번호가 성공적으로 변경되었습니다.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,8 @@ Rails.application.routes.draw do
       post :sign_in, to: 'auth#sign_in'
       delete :sign_out, to: 'auth#sign_out'
 
-      get :confirm_email
-
       resource :reset_password, only: [:create, :update]
+      resource :confirmation, path: 'confirm_email', only: [:create, :update]
     end
   end
 

--- a/spec/controllers/v1/confirmations_controller_spec.rb
+++ b/spec/controllers/v1/confirmations_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe V1::ConfirmationsController, type: :controller do
+  describe 'POST #create' do
+    let(:user) { create(:user) }
+    let(:create_request) { post :create }
+
+    it { expect(create_request).to be_successful }
+    it { expect { create_request }.to change { user.reload.confirmation_token } }
+    it { expect { create_request }.to change { ActionMailer::Base.deliveries.count }.by(1) }
+  end
+
+  describe 'PATCH #update' do
+    let(:auth_token) { nil }
+    let(:user) { create(:user) }
+    let(:confirmation_token) { user.confirmation_token }
+    let(:update_request) { patch :update, params: { confirmation_token: confirmation_token } }
+
+    before { user.issue_confirmation_token }
+
+    it { expect(update_request).to be_successful }
+    it { expect { update_request }.to change { user.reload.confirmed? }.to(true) }
+
+    context 'when user already confirmed email' do
+      let(:user) { create(:user, confirmed_at: DateTime.current) }
+
+      it { expect(update_request).to be_successful }
+      it { expect { update_request }.not_to change { user.reload.confirmed? } }
+    end
+
+    context 'when confirmation token is invalid' do
+      let(:confirmation_token) { 'invalid' }
+
+      it { expect(update_request).not_to be_successful }
+    end
+  end
+end

--- a/spec/controllers/v1/users_controller_spec.rb
+++ b/spec/controllers/v1/users_controller_spec.rb
@@ -75,5 +75,11 @@ RSpec.describe V1::UsersController, type: :controller do
       it { expect(confirm_email_request).to be_successful }
       it { expect { confirm_email_request }.not_to change { user.reload.confirmed? } }
     end
+
+    context 'when confirmation token is invalid' do
+      let(:confirm_email_request) { get :confirm_email, params: { confirmation_token: 'invalid' } }
+
+      it { expect(confirm_email_request).not_to be_successful }
+    end
   end
 end

--- a/spec/controllers/v1/users_controller_spec.rb
+++ b/spec/controllers/v1/users_controller_spec.rb
@@ -58,28 +58,4 @@ RSpec.describe V1::UsersController, type: :controller do
     it { expect(delete_request).to be_successful }
     it { expect { delete_request }.to change(User, :count).by(-1) }
   end
-
-  describe 'GET #confirm_email' do
-    let(:auth_token) { nil }
-    let(:user) { create(:user) }
-    let(:confirm_email_request) { get :confirm_email, params: { confirmation_token: user.confirmation_token } }
-
-    before { user }
-
-    it { expect(confirm_email_request).to be_successful }
-    it { expect { confirm_email_request }.to change { user.reload.confirmed? }.to(true) }
-
-    context 'when user already confirmed email' do
-      let(:user) { create(:user, confirmed_at: DateTime.current) }
-
-      it { expect(confirm_email_request).to be_successful }
-      it { expect { confirm_email_request }.not_to change { user.reload.confirmed? } }
-    end
-
-    context 'when confirmation token is invalid' do
-      let(:confirm_email_request) { get :confirm_email, params: { confirmation_token: 'invalid' } }
-
-      it { expect(confirm_email_request).not_to be_successful }
-    end
-  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe UserMailer, type: :mailer do
     let(:user) { create(:user) }
     let(:mail) { described_class.confirmation_email(user).deliver_now }
 
+    before { user.issue_confirmation_token }
+
     it { expect(mail.subject).not_to be_blank }
     it { expect(mail.to).to eq([user.email]) }
     it { expect(mail.body.encoded).to match(user.confirmation_token) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,23 +32,27 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'confirm_email!' do
+  describe 'confirm_email' do
     let(:user) { build(:user) }
 
-    it { expect { user.confirm_email! }.to change(user, :confirmed?).from(false).to(true) }
+    it { expect { user.confirm_email }.to change(user, :confirmed?).from(false).to(true) }
 
     context 'when already confirmed' do
       let(:user) { build(:user, confirmed_at: Time.now) }
 
-      it { expect{ user.confirm_email! }.not_to change(user, :confirmed?) }
+      it { expect{ user.confirm_email }.not_to change(user, :confirmed?) }
     end
   end
 
-  describe '#set_confirmation_token' do
-    let(:user) { build(:user) }
+  describe '#issue_reset_token' do
+    let(:user) { create(:user) }
 
-    before { user.valid? }
+    it { expect { user.issue_reset_token }.to change { user.reload.reset_token}.from(nil) }
+  end
 
-    it { expect(user.confirmation_token).not_to be_blank }
+  describe '#issue_confirmation_token' do
+    let(:user) { create(:user) }
+
+    it { expect { user.issue_confirmation_token }.to change { user.reload.confirmation_token}.from(nil) }
   end
 end


### PR DESCRIPTION
email confirmation을 별도 컨트롤러로 빼내어 비밀번호 초기화처럼 RESTful하게 변경

* `GET /v1/user/confirm_email`이 `PATCH /v1/user/confirm_email`로 변경됨.
* `POST /v1/user/confirm_email`을 요청하면 인증 메일이 재전송됨(`Authorization` 헤더에 token 필요)