### PR TITLE
Lecture semester

### DIFF
--- a/app/controllers/v1/courses_controller.rb
+++ b/app/controllers/v1/courses_controller.rb
@@ -2,8 +2,9 @@ class V1::CoursesController < V1::BaseController
   skip_before_action :authorize_request
 
   def index
-    @courses = Course.page(params[:page])
-    render jsonapi: @courses
+    @courses = Course.includes(:department).page(params[:page])
+    render jsonapi: @courses,
+           include: [:department]
   end
 
   def search
@@ -15,10 +16,12 @@ class V1::CoursesController < V1::BaseController
     page = params[:page].to_i || 0
 
     @courses = CoursesIndex::Course
-    .query(wildcard: { _all: { value: "*#{query}*" } })
-    .page(page)
-    .objects
+               .load(scope: -> { includes(:department) })
+               .query(wildcard: { _all: { value: "*#{query}*" } })
+               .page(page)
+               .objects
 
-    render jsonapi: @courses
+    render jsonapi: @courses,
+           include: [:department]
   end
 end

--- a/app/controllers/v1/evaluations_controller.rb
+++ b/app/controllers/v1/evaluations_controller.rb
@@ -4,15 +4,15 @@ class V1::EvaluationsController < V1::BaseController
 
   def index
     authorize! :read, Evaluation
-    @evaluations = @lecture.evaluations.page params[:page]
-    render jsonapi: @evaluations
+    @evaluations = @lecture.evaluations.includes(:semester).page(params[:page])
+    render jsonapi: @evaluations, include: [:semester]
   end
 
   def create
     authorize! :create, Evaluation
     @evaluation = Evaluation.new(evaluation_params.merge(user: current_user, lecture: @lecture))
     if @evaluation.save
-      render jsonapi: @evaluation
+      render jsonapi: @evaluation, include: [:semester]
     else
       render jsonapi_errors: @evaluation.errors, status: :unprocessable_entity
     end
@@ -21,13 +21,13 @@ class V1::EvaluationsController < V1::BaseController
   def update
     authorize! :update, @evaluation
     @evaluation.update!(evaluation_params)
-    render jsonapi: @evaluation
+    render jsonapi: @evaluation, include: [:semester]
   end
 
   def destroy
     authorize! :destroy, @evaluation
     @evaluation.destroy
-    render jsonapi: @evaluation
+    render jsonapi: @evaluation, include: [:semester]
   end
 
   private
@@ -41,6 +41,6 @@ class V1::EvaluationsController < V1::BaseController
   end
 
   def evaluation_params
-    params.require(:evaluation).permit(:comment, :score, :easiness, :grading)
+    params.require(:evaluation).permit(:comment, :score, :easiness, :grading, :semester_id)
   end
 end

--- a/app/controllers/v1/lectures_controller.rb
+++ b/app/controllers/v1/lectures_controller.rb
@@ -2,15 +2,17 @@ class V1::LecturesController < V1::BaseController
   skip_before_action :authorize_request
 
   def index
-    @lectures = Lecture.includes(:professor, course: :department).page(params[:page])
+    @lectures = Lecture
+                .includes(:semesters, :professor, course: :department)
+                .page(params[:page])
     render jsonapi: @lectures,
-           include: [{ course: [:department] }, :professor]
+           include: [{ course: [:department] }, :semesters, :professor]
   end
 
   def show
     @lecture = Lecture.find(params[:id])
     render jsonapi: @lecture,
-           include: [{ course: [:department] }, :professor]
+           include: [{ course: [:department] }, :semesters, :professor]
   end
 
   def search
@@ -22,12 +24,12 @@ class V1::LecturesController < V1::BaseController
     page = params[:page].to_i || 0
 
     @lectures = LecturesIndex::Lecture
-                .load(scope: -> { includes(:professor, course: :department) })
+                .load(scope: -> { includes(:semesters, :professor, course: :department) })
                 .query(wildcard: { _all: { value: "*#{query}*" } })
                 .page(page)
                 .objects
 
     render jsonapi: @lectures,
-           include: [{ course: [:department] }, :professor]
+           include: [{ course: [:department] }, :semesters, :professor]
   end
 end

--- a/app/controllers/v1/lectures_controller.rb
+++ b/app/controllers/v1/lectures_controller.rb
@@ -2,15 +2,15 @@ class V1::LecturesController < V1::BaseController
   skip_before_action :authorize_request
 
   def index
-    @lectures = Lecture.includes(:course, :professor).page(params[:page])
+    @lectures = Lecture.includes(:professor, course: :department).page(params[:page])
     render jsonapi: @lectures,
-           include: [:course, :professor]
+           include: [{ course: [:department] }, :professor]
   end
 
   def show
     @lecture = Lecture.find(params[:id])
     render jsonapi: @lecture,
-           include: [:course, :professor]
+           include: [{ course: [:department] }, :professor]
   end
 
   def search
@@ -22,11 +22,12 @@ class V1::LecturesController < V1::BaseController
     page = params[:page].to_i || 0
 
     @lectures = LecturesIndex::Lecture
-    .query(wildcard: { _all: { value: "*#{query}*" } })
-    .page(page)
-    .objects
+                .load(scope: -> { includes(:professor, course: :department) })
+                .query(wildcard: { _all: { value: "*#{query}*" } })
+                .page(page)
+                .objects
 
     render jsonapi: @lectures,
-           include: [:course, :professor]
+           include: [{ course: [:department] }, :professor]
   end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -1,5 +1,6 @@
 class Evaluation < ApplicationRecord
   belongs_to :lecture, counter_cache: true
+  belongs_to :semester, optional: true
   belongs_to :user
 
   validates :comment, length: { minimum: 10 }
@@ -8,10 +9,15 @@ class Evaluation < ApplicationRecord
   validates :grading, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10, only_integer: true }
   validates :user, uniqueness: { scope: :lecture }
 
+  before_validation :set_default_semester
   after_save :update_lecture_scores
   after_destroy :update_lecture_scores
 
   private
+
+  def set_default_semester
+    self.semester ||= lecture.semesters.order(year: :desc, season: :desc).first
+  end
 
   def update_lecture_scores
     lecture.update_scores

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -2,6 +2,8 @@ class Lecture < ApplicationRecord
   belongs_to :course
   belongs_to :professor
   has_many :evaluations
+  has_many :lecture_sessions
+  has_many :semesters, through: :lecture_sessions
 
   update_index('lectures#lecture') { self }
 

--- a/app/models/lecture_session.rb
+++ b/app/models/lecture_session.rb
@@ -1,0 +1,4 @@
+class LectureSession < ApplicationRecord
+  belongs_to :lecture
+  belongs_to :semester
+end

--- a/app/models/semester.rb
+++ b/app/models/semester.rb
@@ -1,2 +1,3 @@
 class Semester < ApplicationRecord
+  enum season: %w[spring summer fall winter]
 end

--- a/app/models/semester.rb
+++ b/app/models/semester.rb
@@ -1,3 +1,5 @@
 class Semester < ApplicationRecord
   enum season: %w[spring summer fall winter]
+
+  validates :season, uniqueness: { scope: :year }
 end

--- a/app/serializable/serializable_course.rb
+++ b/app/serializable/serializable_course.rb
@@ -8,6 +8,6 @@ class SerializableCourse < JSONAPI::Serializable::Resource
   attribute :lab_unit
   attribute :created_at
   attribute :updated_at
-  has_one :department
+  belongs_to :department
   has_many :lectures
 end

--- a/app/serializable/serializable_department.rb
+++ b/app/serializable/serializable_department.rb
@@ -1,0 +1,4 @@
+class SerializableDepartment < JSONAPI::Serializable::Resource
+  type 'departments'
+  attribute :name
+end

--- a/app/serializable/serializable_evaluation.rb
+++ b/app/serializable/serializable_evaluation.rb
@@ -6,6 +6,7 @@ class SerializableEvaluation < JSONAPI::Serializable::Resource
   attribute :grading
   attribute :created_at
   attribute :updated_at
+  belongs_to :semester
 
   attribute :can_update do
     @current_ability.can? :update, @object

--- a/app/serializable/serializable_lecture.rb
+++ b/app/serializable/serializable_lecture.rb
@@ -9,4 +9,5 @@ class SerializableLecture < JSONAPI::Serializable::Resource
   attribute :evaluations_count
   has_one :course
   has_one :professor
+  has_many :semesters
 end

--- a/app/serializable/serializable_semester.rb
+++ b/app/serializable/serializable_semester.rb
@@ -1,0 +1,5 @@
+class SerializableSemester < JSONAPI::Serializable::Resource
+  type 'semesters'
+  attribute :year
+  attribute :season
+end

--- a/db/migrate/20171203140243_create_lecture_sessions.rb
+++ b/db/migrate/20171203140243_create_lecture_sessions.rb
@@ -1,0 +1,15 @@
+class CreateLectureSessions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lecture_sessions do |t|
+      t.integer :target_grade
+      t.string :schedule
+      t.string :classroom
+      t.integer :capacity
+
+      t.belongs_to :lecture
+      t.belongs_to :semester
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180211141632_add_semester_to_evaluations.rb
+++ b/db/migrate/20180211141632_add_semester_to_evaluations.rb
@@ -1,0 +1,5 @@
+class AddSemesterToEvaluations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :evaluations, :semester_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180208140441) do
+ActiveRecord::Schema.define(version: 20180211141632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20180208140441) do
     t.integer "grading", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "semester_id"
     t.index ["lecture_id"], name: "index_evaluations_on_lecture_id"
     t.index ["user_id"], name: "index_evaluations_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,6 +55,19 @@ ActiveRecord::Schema.define(version: 20180208140441) do
     t.index ["user_id"], name: "index_evaluations_on_user_id"
   end
 
+  create_table "lecture_sessions", force: :cascade do |t|
+    t.integer "target_grade"
+    t.string "schedule"
+    t.string "classroom"
+    t.integer "capacity"
+    t.bigint "lecture_id"
+    t.bigint "semester_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lecture_id"], name: "index_lecture_sessions_on_lecture_id"
+    t.index ["semester_id"], name: "index_lecture_sessions_on_semester_id"
+  end
+
   create_table "lectures", force: :cascade do |t|
     t.integer "course_id"
     t.float "score", default: 0.0

--- a/spec/factories/semesters.rb
+++ b/spec/factories/semesters.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :semester do
+    sequence(:year) { |n| 2010 + n / 4 }
+    sequence(:season) { |n| n % 4 }
+  end
+end

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe Evaluation, type: :model do
     it { expect(build(:evaluation, score: 3, easiness: 5, grading: 6)).to be_valid }
   end
 
+  describe '#set_default_semester' do
+    let(:lecture) { create(:lecture) }
+    let(:evaluation) { build(:evaluation, lecture: lecture) }
+
+    before { evaluation.valid? }
+
+    it { expect(evaluation.semester).to eq(nil) }
+
+    context 'when lecture with lecture_sessions' do
+      let(:lecture) { create(:lecture, semesters: semesters) }
+      let(:semesters) { create_list(:semester, 2) }
+
+      it { expect(evaluation.semester).to eq(semesters.last) }
+    end
+  end
+
   describe '.create' do
     let(:lecture) { create(:lecture) }
     let(:user) { create(:user) }

--- a/spec/models/semester_spec.rb
+++ b/spec/models/semester_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Semester, type: :model do
+  describe '#valid?' do
+    it { expect(build(:semester, year: 2018, season: :spring)).to be_valid }
+    it { expect { build(:semester, year: 2018, season: :foo) }.to raise_error(ArgumentError) }
+
+    context 'when same semester exists' do
+      before { create(:semester, year: 2018, season: :spring) }
+
+      it { expect(build(:semester, year: 2018, season: :spring)).not_to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
* legacy 코드베이스의 `SeasonalLecture`의 역할을 하는 join table로 `lecture_sessions`를 추가함.
* 강의평 작성 시 `evaluation[semester_id]`를 포함할 수 있음.
* 생략할 경우 해당 `Lecture` 모델의 가장 최신 학기정보를 자동으로 할당함
* Lecture, Course json에 department 정보 추가.